### PR TITLE
Rewrite rules for sitemap

### DIFF
--- a/.bp-config/httpd/extra/apache-common-rewrites.conf
+++ b/.bp-config/httpd/extra/apache-common-rewrites.conf
@@ -175,6 +175,8 @@ RewriteRule ^/portal/api-suggestions-json.html http://labs.europeana.eu/api/sugg
 RewriteRule ^/portal/api-tag-json.html http://labs.europeana.eu/api/myeuropeana/ [R=301] #new june 2015
 RewriteRule ^/portal/api/console.html http://labs.europeana.eu/api/console [R=301] #new june 2015
 RewriteRule ^/portal/explore.html$ /portal/usingeuropeana_explore.html   [R=301]
+RewriteRule ^/portal/europeana-sitemap-index-hashed.xml /api/europeana-sitemap-index-hashed.xml
+RewriteRule ^/portal/europeana-sitemap-hashed.xml /api/europeana-sitemap-hashed.xml
 RewriteRule ^/portal/languagepolicy.html$ /portal/rights/privacy.html   [R=301]
 RewriteRule ^/portal/pd-usage-guide.html$ /portal/rights/pd-usage-guide.html   [R=301] #new
 RewriteRule ^/portal/privacy.html$ /portal/rights/privacy.html   [R=301]


### PR DESCRIPTION
Sitemaps are served by the API, but have portal URLs.
