### PR TITLE
Redirect https portal traffic to http

### DIFF
--- a/.bp-config/httpd/vhosts/00-www.europeana.eu.conf
+++ b/.bp-config/httpd/vhosts/00-www.europeana.eu.conf
@@ -251,10 +251,10 @@
 
 
     #
-    # Redirect portal requests to https://
+    # Redirect portal requests to http://
     #
-    RewriteCond "%{HTTP:X-Forwarded-Proto}" "http$"
-    RewriteRule ^/portal(.*)$ https://%{HTTP_HOST}/portal$1 [R=301]
+    RewriteCond "%{HTTP:X-Forwarded-Proto}" "https$"
+    RewriteRule ^/portal(.*)$ http://%{HTTP_HOST}/portal$1 [R=301]
 
 
     #
@@ -288,6 +288,6 @@
     #
     # Portal proxying
     #
-    ProxyPass         /portal https://${PORTAL_HOST}/portal interpolate disablereuse=on
-    ProxyPassReverse  /portal https://${PORTAL_HOST}/portal interpolate
+    ProxyPass         /portal http://${PORTAL_HOST}/portal interpolate disablereuse=on
+    ProxyPassReverse  /portal http://${PORTAL_HOST}/portal interpolate
 </VirtualHost>


### PR DESCRIPTION
Because item pages can include non-secure external content.