### PR TITLE
Remove /portal for new record and entity sitemap requests

### DIFF
--- a/.bp-config/httpd/vhosts/00-www.europeana.eu.conf
+++ b/.bp-config/httpd/vhosts/00-www.europeana.eu.conf
@@ -279,8 +279,8 @@
     ProxyPassReverse  /api/fulltext  https://${FULLTEXT_HOST}/presentation interpolate
 
     # Sitemap proxying
-    RewriteRule ^/portal/sitemap-record(.+)$ https://%{ENV:SITEMAP_HOST}/record/sitemap-record$1 [P,L]
-    RewriteRule ^/portal/sitemap-entity(.+)$ https://%{ENV:SITEMAP_HOST}/entity/sitemap-entity$1 [P,L]
+    RewriteRule ^/sitemap-record(.+)$ https://%{ENV:SITEMAP_HOST}/record/sitemap-record$1 [P,L]
+    RewriteRule ^/sitemap-entity(.+)$ https://%{ENV:SITEMAP_HOST}/entity/sitemap-entity$1 [P,L]
     # Old style sitemap requests (kept for now until all search engines start using the new urls)
     RewriteRule ^/portal/europeana-sitemap-index-hashed.xml https://%{ENV:SITEMAP_HOST}/sitemap/europeana-sitemap-index-hashed.xml [P,L]
     RewriteRule ^/portal/europeana-sitemap-hashed.xml https://%{ENV:SITEMAP_HOST}/sitemap/europeana-sitemap-hashed.xml [P,L]


### PR DESCRIPTION
Rationale is that Collections team is apparently considering to remove /portal for all requests and we want to be future proof.